### PR TITLE
Fix isinstance check for subclasses

### DIFF
--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -1,9 +1,14 @@
-from unification.variable import isvar, var, vars, variables
+from unification.variable import isvar, var, vars, variables, Var
 
 
 def test_isvar():
     assert not isvar(3)
     assert isvar(var(3))
+
+    class CustomVar(Var):
+        pass
+
+    assert isvar(CustomVar())
 
 
 def test_var():

--- a/unification/variable.py
+++ b/unification/variable.py
@@ -11,7 +11,7 @@ _glv = _global_logic_variables
 class LVarType(ABCMeta):
     def __instancecheck__(self, o):
         with suppress(TypeError):
-            return issubclass(type(o), LVarType) or o in _glv
+            return issubclass(type(o), (Var, LVarType)) or o in _glv
 
 
 class Var(metaclass=LVarType):


### PR DESCRIPTION
`Var`'s custom `__isinstance__` check wasn't checking for `Var` itself.