### PR TITLE
Introduce a short-circuiting "is ground" predicate

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ from types import MappingProxyType
 from collections import OrderedDict
 
 from unification import var
-from unification.core import reify, unify, unground_lvars
+from unification.core import reify, unify, unground_lvars, isground
 
 
 def test_reify():
@@ -114,4 +114,14 @@ def test_unground_lvars():
     assert (
         unground_lvars((1, [var("a"), [var("b"), 2], 3]), {var("a"): 4, var("b"): 5})
         == set()
+    )
+
+    assert isground((1, 2), {})
+    assert isground((1, var("a")), {var("a"): 2})
+    assert isground([var("a"), [var("b"), 2], 3], {var("a"): var("b"), var("b"): 1})
+    assert not isground((1, var("a")), {var("a"): var("b")})
+    assert not isground((1, var()), {})
+    assert not isground((1, [var("a"), [var("b"), 2], 3]), {})
+    assert not isground(
+        [var("a"), [var("b"), 2], 3], {var("a"): var("b"), var("b"): var("c")}
     )

--- a/unification/core.py
+++ b/unification/core.py
@@ -9,6 +9,10 @@ from .variable import isvar
 from .dispatch import dispatch
 
 
+class UngroundLVarException(Exception):
+    """An exception signaling that an unground variables was found."""
+
+
 @dispatch(object, Mapping)
 def _reify(o, s):
     return o
@@ -153,3 +157,24 @@ def unground_lvars(u, s):
         _reify.add((object, Mapping), _reify_object)
 
     return lvars
+
+
+def isground(u, s):
+    """Determine whether or not `u` contains an unground logic variable under mappings `s`."""
+
+    _reify_object = _reify.dispatch(object, Mapping)
+
+    def _reify_var(u, s):
+        if isvar(u):
+            raise UngroundLVarException()
+        return u
+
+    _reify.add((object, Mapping), _reify_var)
+    try:
+        reify(u, s)
+    except UngroundLVarException:
+        return False
+    finally:
+        _reify.add((object, Mapping), _reify_object)
+
+    return True

--- a/unification/variable.py
+++ b/unification/variable.py
@@ -64,7 +64,9 @@ class Var(metaclass=LVarType):
     __repr__ = __str__
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.token == other.token
+        if type(self) == type(other):
+            return self.token == other.token
+        return NotImplemented
 
     def __hash__(self):
         return hash((type(self), self.token))


### PR DESCRIPTION
Although `unground_lvars` can be used to determine whether or not an object is ground, this `isground` implementation will stop searching immediately after finding an unground logic variable.