### PR TITLE
Fix isground for iterator types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,16 @@ docstyle:
 
 format:
 	@printf "Checking code style with black...\n"
-	black --check unification/
+	black --check unification/ tests/
 	@printf "\033[1;34mBlack passes!\033[0m\n\n"
 
 style:
 	@printf "Checking code style with pylint...\n"
-	pylint unification/
+	pylint unification/ tests/
 	@printf "\033[1;34mPylint passes!\033[0m\n\n"
 
 black:  # Format code in-place using black.
-	black unification/
+	black unification/ tests/
 
 test:  # Test code using pytest.
 	pytest -v tests/ --cov=unification/ --cov-report=xml --html=testing-report.html --self-contained-html

--- a/unification/core.py
+++ b/unification/core.py
@@ -19,7 +19,7 @@ def _reify(o, s):
 
 
 def _reify_Iterable(type_ctor, t, s):
-    return type_ctor(reify(a, s) for a in t)
+    return type_ctor(tuple(reify(a, s) for a in t))
 
 
 for seq, ctor in (
@@ -59,6 +59,7 @@ def reify(e, s):
     >>> reify(e, s)
     {1: 2, 3: (4, 5)}
     """
+
     if isvar(e):
         e = walk(e, s)
     return _reify(e, s)


### PR DESCRIPTION
`isground` wasn't working for input like `iter([var()])`; this fixes that.