### PR TITLE
Introduce stream/trampoline-based reification and unification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ tags
 [._]*.un~
 
 # End of https://www.gitignore.io/api/vim,emacs,python
+
+.benchmarks/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ script:
   - if [[ `command -v black` ]]; then
       black --check unification tests;
     fi
-  - pytest -v tests/ --cov=unification/
+  - pytest -v tests/ --benchmark-skip --cov=unification/
+  - pytest -v tests/ --benchmark-only --benchmark-autosave --benchmark-group-by=group,param:size --benchmark-max-time=3
 
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,14 @@ black:  # Format code in-place using black.
 	black unification/ tests/
 
 test:  # Test code using pytest.
-	pytest -v tests/ --cov=unification/ --cov-report=xml --html=testing-report.html --self-contained-html
+	pytest -v tests/ --benchmark-skip --cov=unification/ --cov-report=xml --html=testing-report.html --self-contained-html
+
+benchmark:
+	pytest -v tests/ --benchmark-only --benchmark-autosave --benchmark-group-by=group,param:size --benchmark-max-time=3
 
 coverage: test
 	diff-cover coverage.xml --compare-branch=master --fail-under=100
 
 lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
 
-check: lint test coverage  # Both lint and test code. Runs `make lint` followed by `make test`.
+check: lint test coverage benchmark  # Both lint and test code. Runs `make lint` followed by `make test`.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ See the full example in the [examples directory](https://github.com/pythological
 
 ## Performance and Reliability
 
-Unification stresses extensibility over performance, preliminary benchmarks show that this is 2-5x slower than straight tuple-based unification.
-
-`unification`'s approach is reliable; although one caveat is set unification, which is challenging to do in general.  It should work well in moderately complex cases, but it may break down under very complex ones.
+`unification`'s current design allows for unification and reification of nested structures that break the Python stack recursion limit.  This scalability incurs an overhead cost compared to simple stack-based recursive unification/reificiation.
 
 ## About
 

--- a/examples/account.py
+++ b/examples/account.py
@@ -1,31 +1,34 @@
 from functools import partial
 from collections import defaultdict
-from unification import *
-from unification.match import *
+
+from unification import var
+from unification.match import match, VarDispatcher
+
 
 match = partial(match, Dispatcher=VarDispatcher)
 
 balance = defaultdict(lambda: 0)
 
-name, amount = var('name'), var('amount')
+name, amount = var("name"), var("amount")
 
-@match({'status': 200, 'data': {'name': name, 'credit': amount}})
+
+@match({"status": 200, "data": {"name": name, "credit": amount}})
 def respond(name, amount):
-    balance[name] +=amount
+    balance[name] += amount
 
 
-@match({'status': 200, 'data': {'name': name, 'debit': amount}})
+@match({"status": 200, "data": {"name": name, "debit": amount}})
 def respond(name, amount):
     balance[name] -= amount
 
 
-@match({'status': 404})
+@match({"status": 404})
 def respond():
     print("Bad Request")
 
 
-if __name__ == '__main__':
-    respond({'status': 200, 'data': {'name': 'Alice', 'credit': 100}})
-    respond({'status': 200, 'data': {'name': 'Bob', 'debit': 100}})
-    respond({'status': 404})
+if __name__ == "__main__":
+    respond({"status": 200, "data": {"name": "Alice", "credit": 100}})
+    respond({"status": 200, "data": {"name": "Bob", "debit": 100}})
+    respond({"status": 404})
     print(dict(balance))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydocstyle>=3.0.0
 pytest>=5.0.0
 pytest-cov>=2.6.1
 pytest-html>=1.20.0
+pytest-benchmark
 pylint>=2.3.1
 black>=19.3b0; platform.python_implementation!='PyPy'
 diff-cover

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,91 @@
+import pytest
+
+from toolz import assoc
+
+from unification import unify, reify, var, isvar
+from unification.utils import transitive_get as walk
+
+from tests.utils import gen_long_chain
+
+
+nesting_sizes = [10, 35, 300]
+
+
+def unify_stack(u, v, s):
+
+    u = walk(u, s)
+    v = walk(v, s)
+
+    if u == v:
+        return s
+    if isvar(u):
+        return assoc(s, u, v)
+    if isvar(v):
+        return assoc(s, v, u)
+
+    if isinstance(u, (tuple, list)) and type(u) == type(v):
+        for i_u, i_v in zip(u, v):
+            s = unify_stack(i_u, i_v, s)
+            if s is False:
+                return s
+
+        return s
+
+    return False
+
+
+def reify_stack(u, s):
+
+    u_ = walk(u, s)
+
+    if u_ is not u:
+        return reify_stack(u_, s)
+
+    if isinstance(u_, (tuple, list)):
+        return type(u_)(reify_stack(i_u, s) for i_u in u_)
+
+    return u_
+
+
+@pytest.mark.benchmark(group="unify_chain")
+@pytest.mark.parametrize("size", nesting_sizes)
+def test_unify_chain_stream(size, benchmark):
+    a_lv = var()
+    form = gen_long_chain(a_lv, size)
+    term = gen_long_chain("a", size)
+
+    res = benchmark(unify, form, term, {})
+    assert res[a_lv] == "a"
+
+
+@pytest.mark.benchmark(group="unify_chain")
+@pytest.mark.parametrize("size", nesting_sizes)
+def test_unify_chain_stack(size, benchmark):
+    a_lv = var()
+    form = gen_long_chain(a_lv, size)
+    term = gen_long_chain("a", size)
+
+    res = benchmark(unify_stack, form, term, {})
+    assert res[a_lv] == "a"
+
+
+@pytest.mark.benchmark(group="reify_chain")
+@pytest.mark.parametrize("size", nesting_sizes)
+def test_reify_chain_stream(size, benchmark):
+    a_lv = var()
+    form = gen_long_chain(a_lv, size)
+    term = gen_long_chain("a", size)
+
+    res = benchmark(reify, form, {a_lv: "a"})
+    assert res == term
+
+
+@pytest.mark.benchmark(group="reify_chain")
+@pytest.mark.parametrize("size", nesting_sizes)
+def test_reify_chain_stack(size, benchmark):
+    a_lv = var()
+    form = gen_long_chain(a_lv, size)
+    term = gen_long_chain("a", size)
+
+    res = benchmark(reify_stack, form, {a_lv: "a"})
+    assert res == term

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,8 @@ from unification import var
 from unification.core import isground, reify, unground_lvars, unify
 from unification.utils import freeze
 
+from tests.utils import gen_long_chain
+
 
 def test_reify():
     x, y, z = var(), var(), var()
@@ -179,15 +181,6 @@ def test_unground_lvars():
     assert CounterList.constructions == 3
 
     assert unground_lvars(test_l, {}) == {a_lv}
-
-
-def gen_long_chain(last_elem=None, N=None):
-    b_struct = None
-    if N is None:
-        N = sys.getrecursionlimit()
-    for i in range(N - 1, 0, -1):
-        b_struct = [i, last_elem if i == N - 1 else b_struct]
-    return b_struct
 
 
 def test_reify_recursion_limit():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 
 from unification import var
 from unification.core import isground, reify, unground_lvars, unify
+from unification.utils import freeze
 
 
 def test_reify():
@@ -230,3 +231,17 @@ def test_unify_recursion_limit():
     s = unify(b, b_var, {})
 
     assert s[a_lv] == "a"
+
+
+def test_unify_freeze():
+
+    # These will sometimes be in different orders after conversion to
+    # `iter`/`list`/`tuple`!
+    # u = frozenset({("name", a), ("debit", b)})
+    # v = frozenset({("name", "Bob"), ("debit", 100)})
+
+    a, b = var("name"), var("amount")
+    u = freeze({"name": a, "debit": b})
+    v = freeze({"name": "Bob", "debit": 100})
+
+    assert unify(u, v, {}) == {a: "Bob", b: 100}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,14 @@
-from unification.utils import freeze
+from unification.variable import var
+from unification.utils import freeze, transitive_get
+
+
+def test_transitive_get():
+    x, y = var(), var()
+    assert transitive_get(x, {x: y, y: 1}) == 1
+    assert transitive_get({1: 2}, {x: y, y: 1}) == {1: 2}
+    # Cycles are not handled
+    # assert transitive_get(x, {x: x}) == x
+    # assert transitive_get(x, {x: y, y: x}) == x
 
 
 def test_freeze():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,6 @@ def test_transitive_get():
 
 
 def test_freeze():
-    assert freeze({1: [2, 3]}) == frozenset([(1, (2, 3))])
-    assert freeze(set([1])) == frozenset([1])
+    assert freeze({1: [2, 3]}) == ((1, (2, 3)),)
+    assert freeze(set([1])) == (1,)
     assert freeze(([1],)) == ((1,),)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def gen_long_chain(last_elem=None, N=None):
+    b_struct = None
+    if N is None:
+        N = sys.getrecursionlimit()
+    for i in range(N - 1, 0, -1):
+        b_struct = [i, last_elem if i == N - 1 else b_struct]
+    return b_struct

--- a/unification/core.py
+++ b/unification/core.py
@@ -134,6 +134,9 @@ def reify(e, s):
     {1: 2, 3: (4, 5)}
     """
 
+    if len(s) == 0:
+        return e
+
     z = _reify(e, s)
     return stream_eval(z)
 

--- a/unification/core.py
+++ b/unification/core.py
@@ -286,3 +286,32 @@ def isground(u, s):
         return False
 
     return True
+
+
+def debug_unify(u, v, s):  # pragma: no cover
+    """Stop in the debugger when unify fails.
+
+    You can inspect the generator-based stack by looking through the
+    generator frames in the `stack` variable in `stream_eval`:
+
+        (Pdb) up
+        > .../unification/unification/core.py(39)stream_eval()
+        -> _ = res_filter(z, z_out)
+        (Pdb) stack[-2].gi_frame.f_locals
+        {'u': <set_iterator at 0x7f5ee32414c8>,
+        'v': <set_iterator at 0x7f5ee3241510>,
+        's': {},
+        'len_u': 2,
+        'len_v': 2,
+        'uu': ('debit', ~amount),
+        'vv': ('name', 'Bob')}
+    """
+
+    def _filter(z, r):
+        if r is False:
+            import pdb
+
+            pdb.set_trace()
+
+    z = _unify(u, v, s)
+    return stream_eval(z, _filter)

--- a/unification/match.py
+++ b/unification/match.py
@@ -1,7 +1,8 @@
+from toolz import groupby, first
+
 from .core import unify, reify
 from .variable import isvar
 from .utils import _toposort, freeze
-from toolz import groupby, first
 
 
 class Dispatcher(object):
@@ -20,18 +21,16 @@ class Dispatcher(object):
 
     def resolve(self, args):
         n = len(args)
+        frozen_args = freeze(args)
         for signature in self.ordering:
             if len(signature) != n:
                 continue
-            s = unify(freeze(args), signature)
+            s = unify(frozen_args, signature)
             if s is not False:
                 result = self.funcs[signature]
                 return result, s
         raise NotImplementedError(
-            "No match found. \nKnown matches: "
-            + str(self.ordering)
-            + "\nInput: "
-            + str(args)
+            f"No match found. \nKnown matches: {self.ordering} \nInput: {args}"
         )
 
     def register(self, *signature):

--- a/unification/utils.py
+++ b/unification/utils.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from collections.abc import Mapping, Set
 
 
 def transitive_get(key, d):
@@ -83,12 +84,12 @@ def freeze(d):
     (1, 2)
 
     >>> freeze({1: 2}) # doctest: +SKIP
-    frozenset([(1, 2)])
+    ((1, 2),)
     """
-    if isinstance(d, dict):
-        return frozenset(map(freeze, d.items()))
-    if isinstance(d, set):
-        return frozenset(map(freeze, d))
+    if isinstance(d, Mapping):
+        return tuple(map(freeze, sorted(d.items(), key=lambda x: hash(x[0]))))
+    if isinstance(d, Set):
+        return tuple(map(freeze, sorted(d, key=hash)))
     if isinstance(d, (tuple, list)):
         return tuple(map(freeze, d))
     return d


### PR DESCRIPTION
This commit introduces a trampoline-style approach to reification and unification.  It's essentially inspired by the miniKanren stream processing alongside which this library is primarily employed.  The main difference is that this implementation employs the `Generator.send` method instead of callables (i.e. goals in miniKanren).

It removes reliance on the Python stack and, as a result, is much more scalable.  Also, it provides a mechanism through which reifiable objects can be traversed but not reconstructed, which greatly reduces the cost of `isground` and `ungrounded_lvars`.

Extensions to the `_unify` and `_reify` dispatch functions must follow the `yield` paradigm by `yield`ing recursive calls to `_unify`/`_reify` and, for `_reify` only, they must precede reified object construction with `yield construction_sentinel` to signal that the next `yield` value will be the reified object (i.e. so that the caller can prevent it, if desired).

Closes #13 and closes #10.