### PR TITLE
Make assoc a generic function

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,8 +1,6 @@
 import pytest
 
-from toolz import assoc
-
-from unification import unify, reify, var, isvar
+from unification import unify, reify, var, isvar, assoc
 from unification.utils import transitive_get as walk
 
 from tests.utils import gen_long_chain

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,10 +6,31 @@ from types import MappingProxyType
 from collections import OrderedDict
 
 from unification import var
-from unification.core import isground, reify, unground_lvars, unify
+from unification.core import isground, reify, unground_lvars, unify, assoc
 from unification.utils import freeze
 
 from tests.utils import gen_long_chain
+
+
+def test_assoc():
+    d = {"a": 1, 2: 2}
+    assert assoc(d, "c", 3) is not d
+    assert assoc(d, "c", 3) == {"a": 1, 2: 2, "c": 3}
+    assert assoc(d, 2, 3) == {"a": 1, 2: 3}
+    assert assoc(d, "a", 0) == {"a": 0, 2: 2}
+    assert d == {"a": 1, 2: 2}
+
+    def assoc_OrderedDict(s, u, v):
+        s[u] = v
+        return s
+
+    assoc.add((OrderedDict, object, object), assoc_OrderedDict)
+
+    x = var()
+    d2 = OrderedDict(d)
+    assert assoc(d2, x, 3) is d2
+    assert assoc(d2, x, 3) == {"a": 1, 2: 2, x: 3}
+    assert assoc(d, x, 3) is not d
 
 
 def test_reify():

--- a/unification/__init__.py
+++ b/unification/__init__.py
@@ -1,4 +1,4 @@
-from .core import unify, reify
+from .core import unify, reify, assoc
 from .more import unifiable
 from .variable import var, isvar, vars, variables, Var
 

--- a/unification/core.py
+++ b/unification/core.py
@@ -1,4 +1,4 @@
-from toolz import assoc
+from copy import copy
 from operator import length_hint
 from functools import partial
 from collections import OrderedDict, deque
@@ -12,6 +12,17 @@ from .dispatch import dispatch
 # An object used to tell the reifier that the next yield constructs the reified
 # object from its constituent refications (if any).
 construction_sentinel = object()
+
+
+@dispatch(Mapping, object, object)
+def assoc(s, u, v):
+    """Add an entry to a `Mapping` and return it."""
+    if hasattr(s, "copy"):
+        s = s.copy()
+    else:
+        s = copy(s)  # pragma: no cover
+    s[u] = v
+    return s
 
 
 def stream_eval(z, res_filter=None):


### PR DESCRIPTION
This allows one to change the behavior of `assoc`, so that it can&mdash;say&mdash;update the substitution `dict` in-place, or perform checks before accepting a unification result.  Furthermore, it's now possible to preserve the `Mapping` type after a new unification entry is added.  The old approach would always return a plain `dict` no matter what type of `Mapping` was given to `unify`.