### PR TITLE
Reify object based on base type

### DIFF
--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,3 +1,4 @@
+from ast import Num
 from collections.abc import Mapping
 
 from unification import var
@@ -27,6 +28,13 @@ def test_unify_object():
     assert stream_eval(_unify_object(Foo(1, 2), Foo(1, 2), {})) == {}
     assert stream_eval(_unify_object(Foo(1, 2), Foo(1, 3), {})) is False
     assert stream_eval(_unify_object(Foo(1, 2), Foo(1, x), {})) == {x: 2}
+
+
+def test_unify_nonstandard_object():
+    x = var()
+    assert stream_eval(_unify_object(Num(n=1), Num(n=1), {})) == {}
+    assert stream_eval(_unify_object(Num(n=1), Num(n=2), {})) is False
+    assert stream_eval(_unify_object(Num(n=1), Num(n=x), {})) == {x: 1}
 
 
 def test_reify_object():

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,4 +1,4 @@
-from ast import Num
+import ast
 from collections.abc import Mapping
 
 from unification import var
@@ -31,10 +31,11 @@ def test_unify_object():
 
 
 def test_unify_nonstandard_object():
+    _unify.add((ast.AST, ast.AST, Mapping), _unify_object)
     x = var()
-    assert stream_eval(_unify_object(Num(n=1), Num(n=1), {})) == {}
-    assert stream_eval(_unify_object(Num(n=1), Num(n=2), {})) is False
-    assert stream_eval(_unify_object(Num(n=1), Num(n=x), {})) == {x: 1}
+    assert unify(ast.Num(n=1), ast.Num(n=1), {}) == {}
+    assert unify(ast.Num(n=1), ast.Num(n=2), {}) is False
+    assert unify(ast.Num(n=1), ast.Num(n=x), {}) == {x: 1}
 
 
 def test_reify_object():
@@ -45,6 +46,14 @@ def test_reify_object():
 
     f = Foo(1, 2)
     assert stream_eval(_reify_object(f, {})) is f
+
+
+def test_reify_nonstandard_object():
+    _reify.add((ast.AST, Mapping), _reify_object)
+    x = var()
+    assert reify(ast.Num(n=1), {}).n == 1
+    assert reify(ast.Num(n=x), {}).n == x
+    assert reify(ast.Num(n=x), {x: 2}).n == 2
 
 
 def test_reify_slots():

--- a/unification/more.py
+++ b/unification/more.py
@@ -53,7 +53,7 @@ def _reify_object(o, s):
 
 
 def _reify_object_dict(o, s):
-    obj = object.__new__(type(o))
+    obj = type(o).__new__(type(o))
 
     d = yield _reify(o.__dict__, s)
 


### PR DESCRIPTION
The currect assumption that `object` can be used to create a new object
is not always valid. One example is the issue I'm currently facing:
```
>>> reify(ast.Num(n=var('x')), {var('x'): 123})
...
     55 def _reify_object_dict(o, s):
---> 56     obj = object.__new__(type(o))
     57
     58     d = yield _reify(o.__dict__, s)

TypeError: object.__new__(Num) is not safe, use Num.__new__()
```